### PR TITLE
Remove 'family' from lattice method names.

### DIFF
--- a/pytac/lattice.py
+++ b/pytac/lattice.py
@@ -120,7 +120,7 @@ class Lattice(object):
 
         return families
 
-    def get_family_pvs(self, family, field, handle):
+    def get_pv_names(self, family, field, handle):
         """Get all pv names for a specific family, field and handle.
 
         Args:
@@ -137,7 +137,7 @@ class Lattice(object):
             pv_names.append(element.get_pv_name(field, handle))
         return pv_names
 
-    def get_family_values(self, family, field, handle='setpoint'):
+    def get_pv_values(self, family, field, handle):
         """Get all pv values for a set of pvs.
 
         Args:
@@ -148,10 +148,10 @@ class Lattice(object):
         Returns:
             list(float): A list of readback or setpoint pv values from the device.
         """
-        pv_names = self.get_family_pvs(family, field, handle)
+        pv_names = self.get_pv_names(family, field, handle)
         return self._cs.get(pv_names)
 
-    def set_family_values(self, family, field, values):
+    def set_pv_values(self, family, field, values):
         """Set the pv value of a given family of pvs.
 
         The pvs are determined by family and device. Note that only setpoint
@@ -167,8 +167,7 @@ class Lattice(object):
             doesn't match the number of found pvs.
 
         """
-        # Get the number of elements in the family
-        pv_names = self.get_family_pvs(family, field, 'setpoint')
+        pv_names = self.get_pv_names(family, field, 'setpoint')
         if len(pv_names) != len(values):
             raise PvException("Number of elements in given array must be equal"
                               "to the number of elements in the lattice")

--- a/test/test_lattice.py
+++ b/test/test_lattice.py
@@ -15,11 +15,8 @@ def simple_element(identity=1):
 
     # Create devices and attach them to the element
     element = pytac.element.Element(identity, 0, 'BPM', cell=1)
-    prefix = 'prefix'
-    rb_suff = ':rb'
-    sp_suff = ':sp'
-    device1 = pytac.device.Device(prefix, mock.MagicMock(), True, sp_suff, rb_suff)
-    device2 = pytac.device.Device(prefix, mock.MagicMock(), True, sp_suff, rb_suff)
+    device1 = pytac.device.Device(PREFIX, mock.MagicMock(), True, RB_SUFFIX, SP_SUFFIX)
+    device2 = pytac.device.Device(PREFIX, mock.MagicMock(), True, RB_SUFFIX, SP_SUFFIX)
     element.add_to_family('family')
 
     element.add_device('x', device1, uc)
@@ -93,22 +90,22 @@ def test_get_all_families(simple_element_and_lattice):
     assert len(families) > 0
 
 
-def test_get_family_values(simple_element_and_lattice):
+def test_get_pv_values(simple_element_and_lattice):
     element, lattice = simple_element_and_lattice
-    lattice.get_family_values('family', 'x')
+    lattice.get_pv_values('family', 'x', pytac.RB)
     lattice._cs.get.assert_called_with([RB_PV])
 
 
-def test_set_family_values(simple_element_and_lattice):
+def test_set_pv_values(simple_element_and_lattice):
     element, lattice = simple_element_and_lattice
-    lattice.set_family_values('family', 'x', [1])
-    lattice._cs.put.assert_called_with([RB_PV], [1])
+    lattice.set_pv_values('family', 'x', [1])
+    lattice._cs.put.assert_called_with([SP_PV], [1])
 
 
-def test_set_family_values_raise_exception(simple_element_and_lattice):
+def test_set_pv_values_raise_exception(simple_element_and_lattice):
     element, lattice = simple_element_and_lattice
     with pytest.raises(PvException):
-        lattice.set_family_values('family','x', [1, 2])
+        lattice.set_pv_values('family','x', [1, 2])
 
 
 def test_s_position(simple_element_and_lattice):

--- a/test/test_machine.py
+++ b/test/test_machine.py
@@ -42,9 +42,9 @@ def test_load_lattice(ring_mode, n_elements, length):
         ('VMX', 173),
         ('DIAD', 173)
     ])
-def test_get_family_pvs(ring_mode, n_bpms):
+def test_get_pv_names(ring_mode, n_bpms):
     lattice = get_lattice(ring_mode)
-    bpm_x_pvs = lattice.get_family_pvs('BPM', 'x', handle='readback')
+    bpm_x_pvs = lattice.get_pv_names('BPM', 'x', handle='readback')
     assert len(bpm_x_pvs) == n_bpms
     for pv in bpm_x_pvs:
         assert re.match('SR.*BPM.*X', pv)


### PR DESCRIPTION
It should be clear from context what the purpose is.