### PR TITLE
Remove bugged method get_cs from class element.

### DIFF
--- a/pytac/element.py
+++ b/pytac/element.py
@@ -208,6 +208,3 @@ class Element(object):
             return self._models[pytac.LIVE].get_pv_name(field, handle)
         except KeyError:
             raise DeviceException('{} has no device for field {}'.format(self, field))
-
-    def get_cs(self, field):
-        return self._devices[field].get_cs()


### PR DESCRIPTION
Removed the get_cs method from the element class as it was bugged because it was trying to us a non-existent attribute.